### PR TITLE
Implement limited supply

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1018,6 +1018,9 @@ int64_t GetProofOfWorkReward(int64_t nFees)
 int64_t GetProofOfStakeReward(int64_t nCoinAge, int64_t nFees)
 {
     int64_t nSubsidy = nCoinAge * COIN_YEAR_REWARD * 33 / (365 * 33 + 8);
+    
+    if (pindexBest->nHeight >= 565916)
+        nSubsidy = 0;
 
     if (fDebug && GetBoolArg("-printcreation"))
         printf("GetProofOfStakeReward(): create=%s nCoinAge=%"PRId64"\n", FormatMoney(nSubsidy).c_str(), nCoinAge);


### PR DESCRIPTION
Emission ends since block 565916 (which is expected by ~04/29/2019).
Further blocks reward contains transaction fees only.

This is necessary in order to comply with announced specification which declares limited supply from the beginning.

Proposed 2 weeks time window would allow more stable network upgrade without breaking consensus in-between.

It's also would be a good idea to bump node's version for ability to track overall network upgrade status.